### PR TITLE
Add script to extract images from Bids dataset to a folder

### DIFF
--- a/dataset_conversion/extract_bids_subject.py
+++ b/dataset_conversion/extract_bids_subject.py
@@ -1,5 +1,5 @@
 """
-Extract image from BIDS dataset into one folder compatible with nnUNet inference.
+Extract image from BIDS dataset into one folder, and possibility to change filename in order to make it compatible with nnUNet inference.
 More information about nnUNet inference format can be found here: https://github.com/MIC-DKFZ/nnUNet/blob/master/documentation/dataset_format_inference.md
 
 Usage example:
@@ -19,13 +19,13 @@ def get_parser():
     parser.add_argument('--path-bids', required=True, help='Path to BIDS dataset. Example: ~/data/dataset')
     parser.add_argument('--path-out', required=True, help='Path to output directory. Example: ~/data/dataset-nnunet')
     parser.add_argument('--contrast', required=True, type=str, help='Contrast of the images to extract. Example: T2w')
-    parser.add_argument('--suffix', required=True, type=int,
-                        help='Contrast in the nnUNet format, 4 digit (maximum) corresponding to the one use in your dataset.json for training. Example: 0')
+    parser.add_argument('--suffix', required=False, type=int, default= -1,
+                        help='If used convert file to nnUNet, if not filename are unchanged. 4 digit (maximum) corresponding to the one use in your dataset.json for training. Example: 0')
     parser.add_argument('--copy', '-cp', type=bool, default=False,
                         help='Making symlink (False) or copying (True) the files in the nnUNet dataset, '
                              'default = False. Example for symlink: --copy True')
     parser.add_argument('--log', type=bool, default=False,
-                        help='Save a csv files with path before and after extraction of the files. Default = false')
+                        help='Save a csv file with path before and after extraction of the files. Default = false')
     return parser
 
 
@@ -47,7 +47,10 @@ def main():
                         extracted_files["old_path"].append(os.path.join(bids_path, item, root, file))
     for i,old_path in enumerate(extracted_files["old_path"]):
         old_name = old_path.split('/')[-1].split('_')[0]
-        new_path = os.path.join(out_path, f"{old_name}_{i:03}_{suffix:04}.nii.gz")
+        if suffix != -1:
+            new_path = os.path.join(out_path, f"{old_name}_{i:03}_{suffix:04}.nii.gz")
+        else:
+            new_path = os.path.join(out_path, old_path.split('/')[-1])
         if copy:
             shutil.copyfile(old_path, new_path)
             extracted_files["new_path"].append(new_path)

--- a/dataset_conversion/extract_bids_subject.py
+++ b/dataset_conversion/extract_bids_subject.py
@@ -20,7 +20,7 @@ def get_parser():
     parser.add_argument('--path-out', required=True, help='Path to output directory. Example: ~/data/dataset-nnunet')
     parser.add_argument('--contrast', required=True, type=str, help='Contrast of the images to extract. Example: T2w')
     parser.add_argument('--suffix', required=False, type=int, default= -1,
-                        help='If used convert file to nnUNet, if not filename are unchanged. 4 digit (maximum) corresponding to the one use in your dataset.json for training. Example: 0')
+                        help='If used convert file to nnUNet format, if not filename are unchanged. 4 digit (maximum) corresponding to the one use in your dataset.json for training. Example: 0')
     parser.add_argument('--copy', '-cp', type=bool, default=False,
                         help='Making symlink (False) or copying (True) the files in the nnUNet dataset, '
                              'default = False. Example for symlink: --copy True')

--- a/dataset_conversion/extract_bids_subject.py
+++ b/dataset_conversion/extract_bids_subject.py
@@ -1,0 +1,65 @@
+"""
+Extract image from BIDS dataset into one folder compatible with nnUNet inference.
+More information about nnUNet inference format can be found here: https://github.com/MIC-DKFZ/nnUNet/blob/master/documentation/dataset_format_inference.md
+
+Usage example:
+    python extract_bids_subject.py --path-bids ~/data/dataset --path-out ~/data/dataset-nnunet --contrast T2w --suffix 0000
+
+Théo Mathieu
+"""
+import argparse
+import os
+import shutil
+import pandas as pd
+
+
+def get_parser():
+    # parse command line arguments
+    parser = argparse.ArgumentParser(description='Extract BIDS image into a folder compatible with nnUNet inference.')
+    parser.add_argument('--path-bids', required=True, help='Path to BIDS dataset. Example: ~/data/dataset')
+    parser.add_argument('--path-out', required=True, help='Path to output directory. Example: ~/data/dataset-nnunet')
+    parser.add_argument('--contrast', required=True, type=str, help='Contrast of the images to extract. Example: T2w')
+    parser.add_argument('--suffix', required=True, type=int,
+                        help='Contrast in the nnUNet format, 4 digit (maximum) corresponding to the one use in your dataset.json for training. Example: 0')
+    parser.add_argument('--copy', '-cp', type=bool, default=False,
+                        help='Making symlink (False) or copying (True) the files in the nnUNet dataset, '
+                             'default = False. Example for symlink: --copy True')
+    parser.add_argument('--log', type=bool, default=False,
+                        help='Save a csv files with path before and after extraction of the files. Default = false')
+    return parser
+
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+    copy = args.copy
+    bids_path = args.path_bids
+    out_path = args.path_out
+    contrast = args.contrast
+    suffix = args.suffix
+    log = args.log
+    extracted_files = {"old_path":[], "new_path":[], "copy/symlink":[]}
+    for item in os.listdir(bids_path):
+        if os.path.isdir(os.path.join(bids_path, item)) and item.startswith("sub-"):
+            for root, _, list_files in os.walk(os.path.join(bids_path,item)):
+                for file in list_files:
+                    if file.endswith(f"_{contrast}.nii.gz"):
+                        extracted_files["old_path"].append(os.path.join(bids_path, item, root, file))
+    for i,old_path in enumerate(extracted_files["old_path"]):
+        old_name = old_path.split('/')[-1].split('_')[0]
+        new_path = os.path.join(out_path, f"{old_name}_{i:03}_{suffix:04}.nii.gz")
+        if copy:
+            shutil.copyfile(old_path, new_path)
+            extracted_files["new_path"].append(new_path)
+            extracted_files["copy/symlink"].append("copy")
+        else:
+            os.symlink(old_path, new_path)
+            extracted_files["new_path"].append(new_path)
+            extracted_files["copy/symlink"].append("symlink")
+    if log:
+        df = pd.DataFrame(extracted_files)
+        df.to_csv(os.path.join(out_path, f"extracted_file.csv"), index=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/dataset_conversion/extract_bids_subject.py
+++ b/dataset_conversion/extract_bids_subject.py
@@ -40,7 +40,7 @@ def main():
     log = args.log
     extracted_files = {"old_path":[], "new_path":[], "copy/symlink":[]}
     for item in os.listdir(bids_path):
-        if os.path.isdir(os.path.join(bids_path, item)) and item.startswith("sub-"):
+        if os.path.isdir(os.path.join(bids_path, item)) and not item.startswith("."):
             for root, _, list_files in os.walk(os.path.join(bids_path,item)):
                 for file in list_files:
                     if file.endswith(f"_{contrast}.nii.gz"):


### PR DESCRIPTION
In the [model-spinal-rootlets](https://github.com/ivadomed/model-spinal-rootlets) project, I used a nnUNet model to predict a complete BIDS dataset. 
To ensure reproducibility, I have created a script that extracts all images of a given contrast from the BIDS dataset and move/copy them to a designated folder. 

I also added an --suffix argument to allow users to convert the image names from BIDS format to nnUNet format if needed.

Perhaps this script can be integrated into the @naga-karthik script [run_nnunet_inference.py](https://github.com/ivadomed/utilities/blob/main/packaging/run_nnunet_inference.py). 
Unless you think that extracting images from a BIDS dataset may have uses beyond nnUNet prediction.