### PR TITLE
Fix nnUNetPredictor inference

### DIFF
--- a/packaging/run_nnunet_inference.py
+++ b/packaging/run_nnunet_inference.py
@@ -12,6 +12,13 @@ from batchgenerators.utilities.file_and_folder_operations import join
 import time
 
 # from nnunetv2.inference.predict_from_raw_data import predict_from_raw_data as predictor
+# silence nnUNet
+if 'nnUNet_raw' not in os.environ:
+        os.environ['nnUNet_raw'] = 'UNDEFINED'
+if 'nnUNet_results' not in os.environ:
+        os.environ['nnUNet_results'] = 'UNDEFINED'
+if 'nnUNet_preprocessed' not in os.environ:
+        os.environ['nnUNet_preprocessed'] = 'UNDEFINED'
 from nnunetv2.inference.predict_from_raw_data import nnUNetPredictor
 
 
@@ -86,7 +93,7 @@ def add_suffix(fname, suffix):
     """
     stem, ext = splitext(fname)
     # we ommit the file extension because nnUNetPredictor takes care of it anyway
-    return os.path.join(stem + suffix)
+    return os.path.join(stem + suffix + ext)
 
 
 def convert_filenames_to_nnunet_format(path_dataset):
@@ -110,13 +117,6 @@ def convert_filenames_to_nnunet_format(path_dataset):
 
 
 def main():
-
-    if 'nnUNet_raw' not in os.environ:
-        os.environ['nnUNet_raw'] = 'UNDEFINED'
-    if 'nnUNet_results' not in os.environ:
-        os.environ['nnUNet_results'] = 'UNDEFINED'
-    if 'nnUNet_preprocessed' not in os.environ:
-        os.environ['nnUNet_preprocessed'] = 'UNDEFINED'
 
     parser = get_parser()
     args = parser.parse_args()
@@ -155,6 +155,8 @@ def main():
         # # add suffix '_pred' to predicted images
         for f in args.path_images:
             fname = Path(f).name
+            # strip ALL suffixes
+            fname = fname.rstrip(''.join(Path(fname).suffixes))
             path_pred = os.path.join(args.path_out, add_suffix(fname, '_pred')) 
             path_out.append(path_pred)
         print(path_out)

--- a/packaging/run_nnunet_inference.py
+++ b/packaging/run_nnunet_inference.py
@@ -126,7 +126,6 @@ def main():
     if args.path_dataset is not None and args.path_images is not None:
         raise ValueError('You can only specify either --path-dataset or --path-images (not both). See --help for more info.')
     
-    inference_mode = None
     if args.path_dataset is not None:
         print('Found a dataset folder. Running inference on the whole dataset...')
 

--- a/packaging/run_nnunet_inference.py
+++ b/packaging/run_nnunet_inference.py
@@ -111,6 +111,13 @@ def convert_filenames_to_nnunet_format(path_dataset):
 
 def main():
 
+    if 'nnUNet_raw' not in os.environ:
+        os.environ['nnUNet_raw'] = 'UNDEFINED'
+    if 'nnUNet_results' not in os.environ:
+        os.environ['nnUNet_results'] = 'UNDEFINED'
+    if 'nnUNet_preprocessed' not in os.environ:
+        os.environ['nnUNet_preprocessed'] = 'UNDEFINED'
+
     parser = get_parser()
     args = parser.parse_args()
 

--- a/packaging/run_nnunet_inference.py
+++ b/packaging/run_nnunet_inference.py
@@ -96,7 +96,7 @@ def convert_filenames_to_nnunet_format(path_dataset):
         os.makedirs(path_tmp, exist_ok=True)
 
     for f in os.listdir(path_dataset):
-        if f.endswith('.nii.gz'):
+        if f.endswith('.nii.gz') or f.endswith('.png'):
             # get absolute path to the image
             f = os.path.join(path_dataset, f)
             # add suffix

--- a/packaging/run_nnunet_inference.py
+++ b/packaging/run_nnunet_inference.py
@@ -85,6 +85,7 @@ def add_suffix(fname, suffix):
     - add_suffix(t2.nii.gz, a) -> t2a.nii.gz
     """
     stem, ext = splitext(fname)
+    # we ommit the file extension because nnUNetPredictor takes care of it anyway
     return os.path.join(stem + suffix)
 
 

--- a/packaging/run_nnunet_inference.py
+++ b/packaging/run_nnunet_inference.py
@@ -129,7 +129,6 @@ def main():
     
     inference_mode = None
     if args.path_dataset is not None:
-        inference_mode = 'dataset'
         print('Found a dataset folder. Running inference on the whole dataset...')
 
         # NOTE: nnUNet only wants the _0000 suffix for files contained in a folder (i.e. when inference is run on a whole dataset)
@@ -142,7 +141,6 @@ def main():
         path_out = args.path_out
 
     elif args.path_images is not None:
-        inference_mode = 'images'
         # NOTE: for individual images, the _0000 suffix is not needed. 
         # BUT, the input images should be in a nested list, and the output paths in a list.
         # get list of images from input argument

--- a/packaging/run_nnunet_inference.py
+++ b/packaging/run_nnunet_inference.py
@@ -92,7 +92,6 @@ def add_suffix(fname, suffix):
     - add_suffix(t2.nii.gz, a) -> t2a.nii.gz
     """
     stem, ext = splitext(fname)
-    # we ommit the file extension because nnUNetPredictor takes care of it anyway
     return os.path.join(stem + suffix + ext)
 
 


### PR DESCRIPTION
So the reason the `--path-dataset` arg did not work for me was because the `convert_filenames_to_nnunet_format` was restricted to NIFTI files. 
However, for `--path-images`, there were problems with the code.

One of the advantage of the new inference interface is that folders or lists of files can be processed using the same method: `nnUNetPredictor.predict_from_files` supports both. Now, this should work for everyone.

Fixes #38 