### PR TITLE
Add python script and quick start guide for MetricsReloaded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
           pip install -r dataset_conversion/requirements.txt
           git clone https://github.com/ivadomed/MetricsReloaded.git
           cd MetricsReloaded
-          git checkout jv/add_rel_vol_error_metric
           python -m pip install .
 
       - name: Run tests with unittest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r dataset_conversion/requirements.txt
+          git clone https://github.com/valosekj/MetricsReloaded.git
+          cd MetricsReloaded
+          git checkout jv/add_rel_vol_error_metric
+          python -m pip install .
 
       - name: Run tests with unittest
         run: |
           python -m unittest tests/test_convert_bids_to_nnUNetV2.py
+          python -m unittest tests/test_compute_metrics_reloaded.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r dataset_conversion/requirements.txt
-          git clone https://github.com/valosekj/MetricsReloaded.git
+          git clone https://github.com/ivadomed/MetricsReloaded.git
           cd MetricsReloaded
           git checkout jv/add_rel_vol_error_metric
           python -m pip install .

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -56,10 +56,13 @@ def get_parser():
 
     # Arguments for model, data, and training
     parser.add_argument('-prediction', required=True, type=str,
-                        help='Path to the nifti image of test prediction.')
+                        help='Path to the folder with nifti images of test predictions or path to a single nifti image '
+                             'of test prediction.')
     parser.add_argument('-reference', required=True, type=str,
-                        help='Path to the nifti image of reference (ground truth) label.')
-    parser.add_argument('-metrics', nargs='+', default=['dsc', 'nsd'], required=False,
+                        help='Path to the folder with nifti images of reference (ground truth) or path to a single '
+                             'nifti image of reference (ground truth).')
+    parser.add_argument('-metrics', nargs='+', default=['dsc', 'fbeta', 'nsd', 'vol_diff', 'rel_vol_diff'],
+                        required=False,
                         help='List of metrics to compute. For details, '
                              'see: https://metricsreloaded.readthedocs.io/en/latest/reference/metrics/metrics.html. '
                              'Default: dsc, nsd')

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -104,7 +104,7 @@ def main():
     for label in unique_labels_reference:
         # create binary masks for the current label
         print(f'Processing label {label}')
-        predidction_data_label = np.array(prediction_data == label, dtype=float)
+        prediction_data_label = np.array(prediction_data == label, dtype=float)
         reference_data_label = np.array(reference_data == label, dtype=float)
 
         # Dice similarity coefficient (DSC):
@@ -113,7 +113,7 @@ def main():
         # Normalized surface distance (NSD):
         # Fig. 86 in https://arxiv.org/pdf/2206.01653v5.pdf
         # https://metricsreloaded.readthedocs.io/en/latest/reference/metrics/pairwise_measures.html#MetricsReloaded.metrics.pairwise_measures.BinaryPairwiseMeasures.normalised_surface_distance
-        bpm = BPM(predidction_data_label, reference_data_label, measures=args.metrics)
+        bpm = BPM(prediction_data_label, reference_data_label, measures=args.metrics)
         dict_seg = bpm.to_dict_meas()
 
         # add the metrics to the output dictionary

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -1,6 +1,6 @@
 """
 Compute MetricsReloaded metrics for segmentation tasks.
-Details: https://github.com/Project-MONAI/MetricsReloaded/tree/main
+Details:  https://github.com/ivadomed/MetricsReloaded
 
 Example usage (single reference-prediction pair):
     python compute_metrics_reloaded.py

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -12,6 +12,13 @@ Default metrics (semantic segmentation):
     - Normalized surface distance (NSD)
 (for details, see Fig. 2, Fig. 11, and Fig. 12 in https://arxiv.org/abs/2206.01653v5)
 
+Dice similarity coefficient (DSC):
+- Fig. 65 in https://arxiv.org/pdf/2206.01653v5.pdf
+- https://metricsreloaded.readthedocs.io/en/latest/reference/metrics/pairwise_measures.html#MetricsReloaded.metrics.pairwise_measures.BinaryPairwiseMeasures.dsc
+Normalized surface distance (NSD):
+- Fig. 86 in https://arxiv.org/pdf/2206.01653v5.pdf
+- https://metricsreloaded.readthedocs.io/en/latest/reference/metrics/pairwise_measures.html#MetricsReloaded.metrics.pairwise_measures.BinaryPairwiseMeasures.normalised_surface_distance
+
 The script is compatible with both binary and multi-class segmentation tasks (e.g., nnunet region-based).
 The metrics are computed for each unique label (class) in the reference (ground truth) image.
 The output is saved to a JSON file, for example:
@@ -115,12 +122,6 @@ def main():
         prediction_data_label = np.array(prediction_data == label, dtype=float)
         reference_data_label = np.array(reference_data == label, dtype=float)
 
-        # Dice similarity coefficient (DSC):
-        # Fig. 65 in https://arxiv.org/pdf/2206.01653v5.pdf
-        # https://metricsreloaded.readthedocs.io/en/latest/reference/metrics/pairwise_measures.html#MetricsReloaded.metrics.pairwise_measures.BinaryPairwiseMeasures.dsc
-        # Normalized surface distance (NSD):
-        # Fig. 86 in https://arxiv.org/pdf/2206.01653v5.pdf
-        # https://metricsreloaded.readthedocs.io/en/latest/reference/metrics/pairwise_measures.html#MetricsReloaded.metrics.pairwise_measures.BinaryPairwiseMeasures.normalised_surface_distance
         bpm = BPM(prediction_data_label, reference_data_label, measures=args.metrics)
         dict_seg = bpm.to_dict_meas()
         # Note:

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -102,9 +102,9 @@ def main():
     # get all unique labels (classes)
     # for example, for nnunet region-based segmentation, spinal cord has label 1, and lesions have label 2
     unique_labels_reference = np.unique(reference_data)
-    unique_labels_reference = unique_labels_reference[unique_labels_reference != 0]  # remove background label
+    unique_labels_reference = unique_labels_reference[unique_labels_reference != 0]  # remove background
     unique_labels_prediction = np.unique(prediction_data)
-    unique_labels_prediction = unique_labels_prediction[unique_labels_prediction != 0]  # remove background label
+    unique_labels_prediction = unique_labels_prediction[unique_labels_prediction != 0]  # remove background
 
     # Get the unique labels that are present in the reference OR prediction images
     unique_labels = np.unique(np.concatenate((unique_labels_reference, unique_labels_prediction)))

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -2,10 +2,15 @@
 Compute MetricsReloaded metrics for segmentation tasks.
 Details: https://github.com/Project-MONAI/MetricsReloaded/tree/main
 
-Example usage:
+Example usage (single reference-prediction pair):
     python compute_metrics_reloaded.py
         -reference sub-001_T2w_seg.nii.gz
         -prediction sub-001_T2w_prediction.nii.gz
+
+Example usage (multiple reference-prediction pairs):
+    python compute_metrics_reloaded.py
+        -reference /path/to/reference
+        -prediction /path/to/prediction
 
 Default metrics (semantic segmentation):
     - Dice similarity coefficient (DSC)

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -56,7 +56,7 @@ def get_parser():
     parser.add_argument('-reference', required=True, type=str,
                         help='Path to the folder with nifti images of reference (ground truth) or path to a single '
                              'nifti image of reference (ground truth).')
-    parser.add_argument('-metrics', nargs='+', default=['dsc', 'fbeta', 'nsd', 'vol_diff', 'rel_vol_diff'],
+    parser.add_argument('-metrics', nargs='+', default=['dsc', 'nsd'],
                         required=False,
                         help='List of metrics to compute. For details, '
                              'see: https://metricsreloaded.readthedocs.io/en/latest/reference/metrics/metrics.html. '

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -46,6 +46,7 @@ import argparse
 import json
 import numpy as np
 import nibabel as nib
+import pandas as pd
 
 from MetricsReloaded.metrics.pairwise_measures import BinaryPairwiseMeasures as BPM
 
@@ -66,8 +67,10 @@ def get_parser():
                         help='List of metrics to compute. For details, '
                              'see: https://metricsreloaded.readthedocs.io/en/latest/reference/metrics/metrics.html. '
                              'Default: dsc, nsd')
-    parser.add_argument('-output', type=str, default='metrics.json', required=False,
-                        help='Path to the output JSON file to save the metrics. Default: metrics.json')
+    parser.add_argument('-output', type=str, default='metrics.csv', required=False,
+                        help='Path to the output CSV file to save the metrics. Default: metrics.csv'
+                             'Metrics are additionally saved to a JSON file with the same name but with .json '
+                             'extension.')
 
     return parser
 
@@ -228,10 +231,15 @@ def main():
     # Convert JSON data to pandas DataFrame
     df = build_output_dataframe(output_list)
 
-    # save dict as json
-    fname_output = os.path.abspath(args.output)
+    # save as CSV
+    fname_output_csv = os.path.abspath(args.output)
+    df.to_csv(fname_output_csv, index=False)
+    print(f'Saved metrics to {fname_output_csv}.')
+
+    # save as JSON
+    fname_output = fname_output_csv.replace('.csv', '.json')
     with open(fname_output, 'w') as f:
-        json.dump(output_dict, f, indent=4)
+        json.dump(output_list, f, indent=4)
     print(f'Saved metrics to {fname_output}.')
 
 

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -1,0 +1,130 @@
+"""
+Compute MetricsReloaded metrics for segmentation tasks.
+Details: https://github.com/Project-MONAI/MetricsReloaded/tree/main
+
+Example usage:
+    python compute_metrics_reloaded.py
+        -reference sub-001_T2w_seg.nii.gz
+        -prediction sub-001_T2w_prediction.nii.gz
+
+Default metrics (semantic segmentation):
+    - Dice similarity coefficient (DSC)
+    - Normalized surface distance (NSD)
+(for details, see Fig. 2, Fig. 11, and Fig. 12 in https://arxiv.org/abs/2206.01653v5)
+
+The script is compatible with both binary and multi-class segmentation tasks (e.g., nnunet region-based).
+The metrics are computed for each unique label (class) in the reference (ground truth) image.
+The output is saved to a JSON file, for example:
+
+{
+    "reference": "sub-001_T2w_seg.nii.gz",
+    "prediction": "sub-001_T2w_prediction.nii.gz",
+    "1.0": {
+        "dsc": 0.8195991091314031,
+        "nsd": 0.9455782312925171
+    },
+    "2.0": {
+        "dsc": 0.8042553191489362,
+        "nsd": 0.9580573951434879
+    }
+
+}
+
+Authors: Jan Valosek
+"""
+
+
+import os
+import argparse
+import json
+import numpy as np
+import nibabel as nib
+
+from MetricsReloaded.metrics.pairwise_measures import BinaryPairwiseMeasures as BPM
+
+
+def get_parser():
+    # parse command line arguments
+    parser = argparse.ArgumentParser(description='Compute MetricsReloaded metrics for segmentation tasks.')
+
+    # Arguments for model, data, and training
+    parser.add_argument('-prediction', required=True, type=str,
+                        help='Path to the nifti image of test prediction.')
+    parser.add_argument('-reference', required=True, type=str,
+                        help='Path to the nifti image of reference (ground truth) label.')
+    parser.add_argument('-metrics', nargs='+', default=['dsc', 'nsd'], required=False,
+                        help='List of metrics to compute. For details, '
+                             'see: https://metricsreloaded.readthedocs.io/en/latest/reference/metrics/metrics.html. '
+                             'Default: dsc, nsd')
+    parser.add_argument('-output', type=str, default='metrics.json', required=False,
+                        help='Path to the output JSON file to save the metrics. Default: metrics.json')
+
+    return parser
+
+
+def load_nifti_image(file_path):
+    """
+    Construct absolute path to the nifti image, check if it exists, and load the image data.
+    :param file_path: path to the nifti image
+    :return: nifti image data
+    """
+    file_path = os.path.expanduser(file_path)   # resolve '~' in the path
+    file_path = os.path.abspath(file_path)
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f'File {file_path} does not exist.')
+    nifti_image = nib.load(file_path)
+    return nifti_image.get_fdata()
+
+
+def main():
+
+    # parse command line arguments
+    parser = get_parser()
+    args = parser.parse_args()
+
+    # load nifti images
+    prediction_data = load_nifti_image(args.prediction)
+    reference_data = load_nifti_image(args.reference)
+
+    # check whether the images have the same shape and orientation
+    if prediction_data.shape != reference_data.shape:
+        raise ValueError(f'The prediction and reference (ground truth) images must have the same shape. '
+                         f'The prediction image has shape {prediction_data.shape} and the ground truth image has '
+                         f'shape {reference_data.shape}.')
+
+    # get all unique labels (classes)
+    # for example, for nnunet region-based segmentation, spinal cord has label 1, and lesions have label 2
+    unique_labels_reference = np.unique(reference_data)
+    unique_labels_reference = unique_labels_reference[unique_labels_reference != 0]  # remove background label
+
+    # create dictionary to store the metrics
+    output_dict = {'reference': args.reference, 'prediction': args.prediction}
+
+    # loop over all unique labels
+    for label in unique_labels_reference:
+        # create binary masks for the current label
+        print(f'Processing label {label}')
+        predidction_data_label = np.array(prediction_data == label, dtype=float)
+        reference_data_label = np.array(reference_data == label, dtype=float)
+
+        # Dice similarity coefficient (DSC):
+        # Fig. 65 in https://arxiv.org/pdf/2206.01653v5.pdf
+        # https://metricsreloaded.readthedocs.io/en/latest/reference/metrics/pairwise_measures.html#MetricsReloaded.metrics.pairwise_measures.BinaryPairwiseMeasures.dsc
+        # Normalized surface distance (NSD):
+        # Fig. 86 in https://arxiv.org/pdf/2206.01653v5.pdf
+        # https://metricsreloaded.readthedocs.io/en/latest/reference/metrics/pairwise_measures.html#MetricsReloaded.metrics.pairwise_measures.BinaryPairwiseMeasures.normalised_surface_distance
+        bpm = BPM(predidction_data_label, reference_data_label, measures=args.metrics)
+        dict_seg = bpm.to_dict_meas()
+
+        # add the metrics to the output dictionary
+        output_dict[label] = dict_seg
+
+    # save dict as json
+    fname_output = os.path.abspath(args.output)
+    with open(fname_output, 'w') as f:
+        json.dump(output_dict, f, indent=4)
+    print(f'Saved metrics to {fname_output}.')
+
+
+if __name__ == '__main__':
+    main()

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -128,6 +128,11 @@ def main():
         #  - if the reference is NOT empty and the prediction is empty the DSC and NSD are set to 0.0
         #  - if the reference is empty and the prediction is NOT empty the DSC and NSD are set to 0.0
         #  - if the reference and the prediction are both empty the DSC and NSD are set to 1.0
+        # Store info whether the reference or prediction is empty
+        dict_seg['EmptyRef'] = bpm.flag_empty_ref
+        dict_seg['EmptyPred'] = bpm.flag_empty_pred
+        # add the metrics to the output dictionary
+        output_dict[label] = dict_seg
 
         # add the metrics to the output dictionary
         output_dict[label] = dict_seg

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -163,7 +163,7 @@ def compute_metrics_single_subject(prediction, reference, metrics):
             break       # break to loop to avoid processing the background label ("else" block)
     # Special case when both the reference and prediction images are empty
     else:
-        label = 0
+        label = 1
         print(f'Processing label {label} -- both the reference and prediction are empty')
         bpm = BPM(prediction_data, reference_data, measures=metrics)
         dict_seg = bpm.to_dict_meas()

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -66,11 +66,11 @@ def get_parser():
     parser.add_argument('-reference', required=True, type=str,
                         help='Path to the folder with nifti images of reference (ground truth) or path to a single '
                              'nifti image of reference (ground truth).')
-    parser.add_argument('-metrics', nargs='+', default=['dsc', 'nsd'],
+    parser.add_argument('-metrics', nargs='+', default=['dsc', 'fbeta', 'nsd', 'vol_diff', 'rel_vol_error'],
                         required=False,
                         help='List of metrics to compute. For details, '
                              'see: https://metricsreloaded.readthedocs.io/en/latest/reference/metrics/metrics.html. '
-                             'Default: dsc, nsd')
+                             'Default: dsc, fbeta, nsd, vol_diff, rel_vol_error')
     parser.add_argument('-output', type=str, default='metrics.csv', required=False,
                         help='Path to the output CSV file to save the metrics. Default: metrics.csv')
 

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -124,10 +124,6 @@ def main():
 
         bpm = BPM(prediction_data_label, reference_data_label, measures=args.metrics)
         dict_seg = bpm.to_dict_meas()
-        # Note:
-        #  - if the reference is NOT empty and the prediction is empty the DSC and NSD are set to 0.0
-        #  - if the reference is empty and the prediction is NOT empty the DSC and NSD are set to 0.0
-        #  - if the reference and the prediction are both empty the DSC and NSD are set to 1.0
         # Store info whether the reference or prediction is empty
         dict_seg['EmptyRef'] = bpm.flag_empty_ref
         dict_seg['EmptyPred'] = bpm.flag_empty_pred

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -108,9 +108,6 @@ def main():
 
     # Get the unique labels that are present in the reference OR prediction images
     unique_labels = np.unique(np.concatenate((unique_labels_reference, unique_labels_prediction)))
-    # If both the reference and prediction images are empty, the unique_labels will be [0]
-    if len(unique_labels) == 0:
-        unique_labels = [0]
 
     # create dictionary to store the metrics
     output_dict = {'reference': args.reference, 'prediction': args.prediction}
@@ -130,6 +127,18 @@ def main():
         # add the metrics to the output dictionary
         output_dict[label] = dict_seg
 
+        if label == max(unique_labels):
+            break       # break to loop to avoid processing the background label ("else" block)
+    # Special case when both the reference and prediction images are empty
+    else:
+        label = 0
+        print(f'Processing label {label} -- both the reference and prediction are empty')
+        bpm = BPM(prediction_data, reference_data, measures=args.metrics)
+        dict_seg = bpm.to_dict_meas()
+
+        # Store info whether the reference or prediction is empty
+        dict_seg['EmptyRef'] = bpm.flag_empty_ref
+        dict_seg['EmptyPred'] = bpm.flag_empty_pred
         # add the metrics to the output dictionary
         output_dict[label] = dict_seg
 

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -21,21 +21,11 @@ Normalized surface distance (NSD):
 
 The script is compatible with both binary and multi-class segmentation tasks (e.g., nnunet region-based).
 The metrics are computed for each unique label (class) in the reference (ground truth) image.
-The output is saved to a JSON file, for example:
+The output is saved to a CSV file, for example:
 
-{
-    "reference": "sub-001_T2w_seg.nii.gz",
-    "prediction": "sub-001_T2w_prediction.nii.gz",
-    "1.0": {
-        "dsc": 0.8195991091314031,
-        "nsd": 0.9455782312925171
-    },
-    "2.0": {
-        "dsc": 0.8042553191489362,
-        "nsd": 0.9580573951434879
-    }
-
-}
+reference	prediction	label	dsc	fbeta	nsd	vol_diff	rel_vol_diff	EmptyRef	EmptyPred
+seg.nii.gz	pred.nii.gz	1.0	0.819	0.819	0.945	0.105	-10.548	False	False
+seg.nii.gz	pred.nii.gz	2.0	0.743	0.743	0.923	0.121	-11.423	False	False
 
 Authors: Jan Valosek
 """
@@ -43,7 +33,6 @@ Authors: Jan Valosek
 
 import os
 import argparse
-import json
 import numpy as np
 import nibabel as nib
 import pandas as pd
@@ -68,9 +57,7 @@ def get_parser():
                              'see: https://metricsreloaded.readthedocs.io/en/latest/reference/metrics/metrics.html. '
                              'Default: dsc, nsd')
     parser.add_argument('-output', type=str, default='metrics.csv', required=False,
-                        help='Path to the output CSV file to save the metrics. Default: metrics.csv'
-                             'Metrics are additionally saved to a JSON file with the same name but with .json '
-                             'extension.')
+                        help='Path to the output CSV file to save the metrics. Default: metrics.csv')
 
     return parser
 
@@ -208,7 +195,7 @@ def main():
     parser = get_parser()
     args = parser.parse_args()
 
-    # Initialize the output JSON
+    # Initialize a list to store the output dictionaries (representing a single reference-prediction pair per subject)
     output_list = list()
 
     # Args.prediction and args.reference are paths to folders with multiple nii.gz files (i.e., multiple subjects)
@@ -235,12 +222,6 @@ def main():
     fname_output_csv = os.path.abspath(args.output)
     df.to_csv(fname_output_csv, index=False)
     print(f'Saved metrics to {fname_output_csv}.')
-
-    # save as JSON
-    fname_output = fname_output_csv.replace('.csv', '.json')
-    with open(fname_output, 'w') as f:
-        json.dump(output_list, f, indent=4)
-    print(f'Saved metrics to {fname_output}.')
 
 
 if __name__ == '__main__':

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -223,6 +223,15 @@ def main():
     df.to_csv(fname_output_csv, index=False)
     print(f'Saved metrics to {fname_output_csv}.')
 
+    # Compute mean and standard deviation of metrics across all subjects
+    df_mean = (df.drop(columns=['reference', 'prediction', 'EmptyRef', 'EmptyPred']).groupby('label').
+               agg(['mean', 'std']).reset_index())
+
+    # save as CSV
+    fname_output_csv_mean = os.path.abspath(args.output.replace('.csv', '_mean.csv'))
+    df_mean.to_csv(fname_output_csv_mean, index=False)
+    print(f'Saved mean and standard deviation of metrics across all subjects to {fname_output_csv_mean}.')
+
 
 if __name__ == '__main__':
     main()

--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -45,6 +45,16 @@ import pandas as pd
 from MetricsReloaded.metrics.pairwise_measures import BinaryPairwiseMeasures as BPM
 
 
+METRICS_TO_NAME = {
+    'dsc': 'Dice similarity coefficient (DSC)',
+    'hd': 'Hausdorff distance',
+    'fbeta': 'FBeta score',
+    'nsd': 'Normalized surface distance (NSD)',
+    'vol_diff': 'Volume difference',
+    'rel_vol_diff': 'Relative volume error (RVE)',
+}
+
+
 def get_parser():
     # parse command line arguments
     parser = argparse.ArgumentParser(description='Compute MetricsReloaded metrics for segmentation tasks.')
@@ -222,6 +232,9 @@ def main():
 
     # Convert JSON data to pandas DataFrame
     df = build_output_dataframe(output_list)
+
+    # Rename columns
+    df.rename(columns={metric: METRICS_TO_NAME[metric] for metric in METRICS_TO_NAME}, inplace=True)
 
     # save as CSV
     fname_output_csv = os.path.abspath(args.output)

--- a/quick_start_guides/MetricsReloaded_quick_start_guide.md
+++ b/quick_start_guides/MetricsReloaded_quick_start_guide.md
@@ -4,6 +4,7 @@ Useful links:
 - [MetricsReloaded GitHub page](https://github.com/Project-MONAI/MetricsReloaded)
 - [MetricsReloaded documentation](https://metricsreloaded.readthedocs.io/en/latest/)
 - [MetricsReloaded publication](https://www.nature.com/articles/s41592-023-02151-z)
+- [MetricsReloaded preprint](https://arxiv.org/pdf/2206.01653v5.pdf) - preprint contains more figures than the publication
 
 ## Installation
 

--- a/quick_start_guides/MetricsReloaded_quick_start_guide.md
+++ b/quick_start_guides/MetricsReloaded_quick_start_guide.md
@@ -1,14 +1,17 @@
 # MetricsReloaded quick-start guide
 
 Useful links:
-- [MetricsReloaded GitHub page](https://github.com/Project-MONAI/MetricsReloaded)
 - [MetricsReloaded documentation](https://metricsreloaded.readthedocs.io/en/latest/)
 - [MetricsReloaded publication](https://www.nature.com/articles/s41592-023-02151-z)
 - [MetricsReloaded preprint](https://arxiv.org/pdf/2206.01653v5.pdf) - preprint contains more figures than the publication
 
 ## Installation
 
-Official installation instructions are available [here](https://github.com/Project-MONAI/MetricsReloaded?tab=readme-ov-file#installation).
+The installation instructions are available [here](https://github.com/ivadomed/MetricsReloaded?tab=readme-ov-file#installation).
+
+> **Note**
+> Note that we use an ivadomed fork.
+
 
 > **Note**
 > Always install MetricsReloaded inside a virtual environment.
@@ -20,7 +23,7 @@ conda activate metrics_reloaded
 
 # Clone the repository
 cd ~/code
-git clone https://github.com/csudre/MetricsReloaded.git
+git clone https://github.com/ivadomed/MetricsReloaded
 cd MetricsReloaded
 
 # Install the package

--- a/quick_start_guides/MetricsReloaded_quick_start_guide.md
+++ b/quick_start_guides/MetricsReloaded_quick_start_guide.md
@@ -1,0 +1,64 @@
+# MetricsReloaded quick-start guide
+
+Useful links:
+- [MetricsReloaded GitHub page](https://github.com/Project-MONAI/MetricsReloaded)
+- [MetricsReloaded documentation](https://metricsreloaded.readthedocs.io/en/latest/)
+- [MetricsReloaded publication](https://www.nature.com/articles/s41592-023-02151-z)
+
+## Installation
+
+Official installation instructions are available [here](https://github.com/Project-MONAI/MetricsReloaded?tab=readme-ov-file#installation).
+
+> **Note**
+> Always install MetricsReloaded inside a virtual environment.
+
+```
+# Create and activate a new conda environment
+conda create -n metrics_reloaded python=3.10 pip
+conda activate metrics_reloaded
+
+# Clone the repository
+cd ~/code
+git clone https://github.com/csudre/MetricsReloaded.git
+cd MetricsReloaded
+
+# Install the package
+python -m pip install .
+# You can alternatively install the package in editable mode:
+python -m pip install -e .
+```
+
+## Usage
+
+You can use the [compute_metrics_reloaded.py](../compute_metrics/compute_metrics_reloaded.py) script to compute metrics using the MetricsReloaded package.
+
+```commandline
+python compute_metrics_reloaded.py -reference sub-001_T2w_seg.nii.gz -prediction sub-001_T2w_prediction.nii.gz 
+```
+
+Default metrics (semantic segmentation):
+    - Dice similarity coefficient (DSC)
+    - Normalized surface distance (NSD)
+(for details, see Fig. 2, Fig. 11, and Fig. 12 in https://arxiv.org/abs/2206.01653v5)
+
+The script is compatible with both binary and multi-class segmentation tasks (e.g., nnunet region-based).
+
+The metrics are computed for each unique label (class) in the reference (ground truth) image.
+
+The output is saved to a JSON file, for example:
+
+```json
+{
+    "reference": "sub-001_T2w_seg.nii.gz",
+    "prediction": "sub-001_T2w_prediction.nii.gz",
+    "1.0": {
+        "dsc": 0.8195991091314031,
+        "nsd": 0.9455782312925171
+    },
+    "2.0": {
+        "dsc": 0.8042553191489362,
+        "nsd": 0.9580573951434879
+    }
+
+}
+```

--- a/quick_start_guides/MetricsReloaded_quick_start_guide.md
+++ b/quick_start_guides/MetricsReloaded_quick_start_guide.md
@@ -46,20 +46,10 @@ The script is compatible with both binary and multi-class segmentation tasks (e.
 
 The metrics are computed for each unique label (class) in the reference (ground truth) image.
 
-The output is saved to a JSON file, for example:
+The output is saved to a CSV file, for example:
 
-```json
-{
-    "reference": "sub-001_T2w_seg.nii.gz",
-    "prediction": "sub-001_T2w_prediction.nii.gz",
-    "1.0": {
-        "dsc": 0.8195991091314031,
-        "nsd": 0.9455782312925171
-    },
-    "2.0": {
-        "dsc": 0.8042553191489362,
-        "nsd": 0.9580573951434879
-    }
-
-}
+```csv
+reference   prediction	label	dsc	fbeta	nsd	vol_diff	rel_vol_diff	EmptyRef	EmptyPred
+seg.nii.gz	pred.nii.gz	1.0	0.819	0.819	0.945	0.105	-10.548	False	False
+seg.nii.gz	pred.nii.gz	2.0	0.743	0.743	0.923	0.121	-11.423	False	False
 ```

--- a/tests/test_compute_metrics_reloaded.py
+++ b/tests/test_compute_metrics_reloaded.py
@@ -53,13 +53,13 @@ class TestComputeMetricsReloaded(unittest.TestCase):
         Empty reference and empty prediction
         """
 
-        expected_metrics = {'EmptyPred': True,
-                            'EmptyRef': True,
-                            'dsc': 1,
-                            'fbeta': 1,
-                            'nsd': np.nan,
-                            'rel_vol_error': 0,
-                            'vol_diff': np.nan}
+        expected_metrics = {1.0: {'EmptyPred': True,
+                                  'EmptyRef': True,
+                                  'dsc': 1,
+                                  'fbeta': 1,
+                                  'nsd': np.nan,
+                                  'rel_vol_error': 0,
+                                  'vol_diff': np.nan}}
 
         # Create empty reference
         self.create_dummy_nii(self.ref_file, np.zeros((10, 10, 10)))
@@ -75,13 +75,13 @@ class TestComputeMetricsReloaded(unittest.TestCase):
         Empty reference and non-empty prediction
         """
 
-        expected_metrics = {'EmptyPred': False,
-                            'EmptyRef': True,
-                            'dsc': 0.0,
-                            'fbeta': 0,
-                            'nsd': 0.0,
-                            'rel_vol_error': 100,
-                            'vol_diff': np.inf}
+        expected_metrics = {1.0: {'EmptyPred': False,
+                                  'EmptyRef': True,
+                                  'dsc': 0.0,
+                                  'fbeta': 0,
+                                  'nsd': 0.0,
+                                  'rel_vol_error': 100,
+                                  'vol_diff': np.inf}}
 
         # Create empty reference
         self.create_dummy_nii(self.ref_file, np.zeros((10, 10, 10)))
@@ -99,13 +99,13 @@ class TestComputeMetricsReloaded(unittest.TestCase):
         Non-empty reference and empty prediction
         """
 
-        expected_metrics = {'EmptyPred': True,
-                            'EmptyRef': False,
-                            'dsc': 0.0,
-                            'fbeta': 0,
-                            'nsd': 0.0,
-                            'rel_vol_error': -100.0,
-                            'vol_diff': 1.0}
+        expected_metrics = {1.0: {'EmptyPred': True,
+                                  'EmptyRef': False,
+                                  'dsc': 0.0,
+                                  'fbeta': 0,
+                                  'nsd': 0.0,
+                                  'rel_vol_error': -100.0,
+                                  'vol_diff': 1.0}}
 
         # Create non-empty reference
         ref = np.zeros((10, 10, 10))
@@ -123,13 +123,13 @@ class TestComputeMetricsReloaded(unittest.TestCase):
         Non-empty reference and non-empty prediction with partial overlap
         """
 
-        expected_metrics = {'EmptyPred': False,
-                            'EmptyRef': False,
-                            'dsc': 0.26666666666666666,
-                            'fbeta': 0.26666667461395266,
-                            'nsd': 0.5373134328358209,
-                            'rel_vol_error': 300.0,
-                            'vol_diff': 3.0}
+        expected_metrics = {1.0: {'EmptyPred': False,
+                                  'EmptyRef': False,
+                                  'dsc': 0.26666666666666666,
+                                  'fbeta': 0.26666667461395266,
+                                  'nsd': 0.5373134328358209,
+                                  'rel_vol_error': 300.0,
+                                  'vol_diff': 3.0}}
 
         # Create non-empty reference
         ref = np.zeros((10, 10, 10))
@@ -185,13 +185,13 @@ class TestComputeMetricsReloaded(unittest.TestCase):
         Non-empty reference and non-empty prediction with full overlap
         """
 
-        expected_metrics = {'EmptyPred': False,
-                            'EmptyRef': False,
-                            'dsc': 1.0,
-                            'fbeta': 1.0,
-                            'nsd': 1.0,
-                            'rel_vol_error': 0.0,
-                            'vol_diff': 0.0}
+        expected_metrics = {1.0: {'EmptyPred': False,
+                                  'EmptyRef': False,
+                                  'dsc': 1.0,
+                                  'fbeta': 1.0,
+                                  'nsd': 1.0,
+                                  'rel_vol_error': 0.0,
+                                  'vol_diff': 0.0}}
 
         # Create non-empty reference
         ref = np.zeros((10, 10, 10))

--- a/tests/test_compute_metrics_reloaded.py
+++ b/tests/test_compute_metrics_reloaded.py
@@ -118,7 +118,7 @@ class TestComputeMetricsReloaded(unittest.TestCase):
 
     def test_non_empty_ref_and_pred(self):
         """
-        Non-empty reference and non-empty prediction
+        Non-empty reference and non-empty prediction with partial overlap
         """
 
         expected_metrics = {'EmptyPred': False,
@@ -132,6 +132,32 @@ class TestComputeMetricsReloaded(unittest.TestCase):
         # Create non-empty reference
         ref = np.zeros((10, 10, 10))
         ref[4:5, 3:6] = 1
+        self.create_dummy_nii(self.ref_file, ref)
+        # Create non-empty prediction
+        pred = np.zeros((10, 10, 10))
+        pred[4:8, 2:5] = 1
+        self.create_dummy_nii(self.pred_file, pred)
+        # Compute metrics
+        metrics_dict = compute_metrics_single_subject(self.pred_file.name, self.ref_file.name, self.metrics)
+        # Assert metrics
+        self.assert_metrics(metrics_dict, expected_metrics)
+
+    def test_non_empty_ref_and_pred_with_full_overlap(self):
+        """
+        Non-empty reference and non-empty prediction with full overlap
+        """
+
+        expected_metrics = {'EmptyPred': False,
+                            'EmptyRef': False,
+                            'dsc': 1.0,
+                            'fbeta': 1.0,
+                            'nsd': 1.0,
+                            'rel_vol_error': 0.0,
+                            'vol_diff': 0.0}
+
+        # Create non-empty reference
+        ref = np.zeros((10, 10, 10))
+        ref[4:8, 2:5] = 1
         self.create_dummy_nii(self.ref_file, ref)
         # Create non-empty prediction
         pred = np.zeros((10, 10, 10))


### PR DESCRIPTION
## Description

This PR adds:
- [MetricsReloaded_quick_start_guide.md](https://github.com/ivadomed/utilities/blob/3d0bce83488453eb5f454e506bb4555591735151/quick_start_guides/MetricsReloaded_quick_start_guide.md) providing instructions on how to install [MetricsReloaded](https://github.com/ivadomed/MetricsReloaded) and use it
- [compute_metrics_reloaded.py](https://github.com/ivadomed/utilities/blob/3d0bce83488453eb5f454e506bb4555591735151/compute_metrics/compute_metrics_reloaded.py) to compute segmentation metrics using [MetricsReloaded](https://github.com/ivadomed/MetricsReloaded/tree/main) and save them into a CSV file

## Useful links:

- [MetricsReloaded GitHub page](https://github.com/Project-MONAI/MetricsReloaded)
- [Our ivadomed fork](https://github.com/ivadomed/MetricsReloaded/tree/main)
- [MetricsReloaded documentation](https://metricsreloaded.readthedocs.io/en/latest/)
- [MetricsReloaded publication](https://www.nature.com/articles/s41592-023-02151-z)
- [MetricsReloaded preprint](https://arxiv.org/pdf/2206.01653v5.pdf) - preprint contains more figures than the publication