### PR TITLE
Add lesion-wise metrics

### DIFF
--- a/compute_metrics/compute_metrics_reloaded.py
+++ b/compute_metrics/compute_metrics_reloaded.py
@@ -52,6 +52,9 @@ METRICS_TO_NAME = {
     'nsd': 'Normalized surface distance (NSD)',
     'vol_diff': 'Volume difference',
     'rel_vol_error': 'Relative volume error (RVE)',
+    'lesion_ppv': 'Lesion wise positive predictive value (PPV)',
+    'lesion_sensitivity': 'Lesion wise sensitivity',
+    'lesion_f1_score': 'Lesion wise F1 score',
 }
 
 

--- a/tests/test_compute_metrics_reloaded.py
+++ b/tests/test_compute_metrics_reloaded.py
@@ -112,7 +112,7 @@ class TestComputeMetricsReloaded(unittest.TestCase):
                                   'nsd': 0.0,
                                   'rel_vol_error': -100.0,
                                   'vol_diff': 1.0,
-                                  'lesion_ppv': 1.0,
+                                  'lesion_ppv': 0.0,
                                   'lesion_sensitivity': 0.0,
                                   'lesion_f1_score': 0.0}}
 

--- a/tests/test_compute_metrics_reloaded.py
+++ b/tests/test_compute_metrics_reloaded.py
@@ -13,7 +13,7 @@ import nibabel as nib
 from compute_metrics.compute_metrics_reloaded import compute_metrics_single_subject
 import tempfile
 
-METRICS = ['dsc', 'fbeta', 'nsd', 'vol_diff', 'rel_vol_error']
+METRICS = ['dsc', 'fbeta', 'nsd', 'vol_diff', 'rel_vol_error', 'lesion_ppv', 'lesion_sensitivity', 'lesion_f1_score']
 
 
 class TestComputeMetricsReloaded(unittest.TestCase):
@@ -59,7 +59,10 @@ class TestComputeMetricsReloaded(unittest.TestCase):
                                   'fbeta': 1,
                                   'nsd': np.nan,
                                   'rel_vol_error': 0,
-                                  'vol_diff': np.nan}}
+                                  'vol_diff': np.nan,
+                                  'lesion_ppv': 1.0,
+                                  'lesion_sensitivity': 1.0,
+                                  'lesion_f1_score': 1.0}}
 
         # Create empty reference
         self.create_dummy_nii(self.ref_file, np.zeros((10, 10, 10)))
@@ -81,7 +84,10 @@ class TestComputeMetricsReloaded(unittest.TestCase):
                                   'fbeta': 0,
                                   'nsd': 0.0,
                                   'rel_vol_error': 100,
-                                  'vol_diff': np.inf}}
+                                  'vol_diff': np.inf,
+                                  'lesion_ppv': 0.0,
+                                  'lesion_sensitivity': 1.0,
+                                  'lesion_f1_score': 0.0}}
 
         # Create empty reference
         self.create_dummy_nii(self.ref_file, np.zeros((10, 10, 10)))
@@ -105,7 +111,10 @@ class TestComputeMetricsReloaded(unittest.TestCase):
                                   'fbeta': 0,
                                   'nsd': 0.0,
                                   'rel_vol_error': -100.0,
-                                  'vol_diff': 1.0}}
+                                  'vol_diff': 1.0,
+                                  'lesion_ppv': 1.0,
+                                  'lesion_sensitivity': 0.0,
+                                  'lesion_f1_score': 0.0}}
 
         # Create non-empty reference
         ref = np.zeros((10, 10, 10))
@@ -129,7 +138,10 @@ class TestComputeMetricsReloaded(unittest.TestCase):
                                   'fbeta': 0.26666667461395266,
                                   'nsd': 0.5373134328358209,
                                   'rel_vol_error': 300.0,
-                                  'vol_diff': 3.0}}
+                                  'vol_diff': 3.0,
+                                  'lesion_ppv': 1.0,
+                                  'lesion_sensitivity': 1.0,
+                                  'lesion_f1_score': 1.0}}
 
         # Create non-empty reference
         ref = np.zeros((10, 10, 10))
@@ -156,14 +168,20 @@ class TestComputeMetricsReloaded(unittest.TestCase):
                                   'vol_diff': 2.0,
                                   'rel_vol_error': 200.0,
                                   'EmptyRef': False,
-                                  'EmptyPred': False},
+                                  'EmptyPred': False,
+                                  'lesion_ppv': 1.0,
+                                  'lesion_sensitivity': 1.0,
+                                  'lesion_f1_score': 1.0},
                             2.0: {'dsc': 0.26666666666666666,
                                   'fbeta': 0.26666667461395266,
                                   'nsd': 0.5373134328358209,
                                   'vol_diff': 3.0,
                                   'rel_vol_error': 300.0,
                                   'EmptyRef': False,
-                                  'EmptyPred': False}}
+                                  'EmptyPred': False,
+                                  'lesion_ppv': 1.0,
+                                  'lesion_sensitivity': 1.0,
+                                  'lesion_f1_score': 1.0}}
 
         # Create non-empty reference
         ref = np.zeros((10, 10, 10))
@@ -191,7 +209,10 @@ class TestComputeMetricsReloaded(unittest.TestCase):
                                   'fbeta': 1.0,
                                   'nsd': 1.0,
                                   'rel_vol_error': 0.0,
-                                  'vol_diff': 0.0}}
+                                  'vol_diff': 0.0,
+                                  'lesion_ppv': 1.0,
+                                  'lesion_sensitivity': 1.0,
+                                  'lesion_f1_score': 1.0}}
 
         # Create non-empty reference
         ref = np.zeros((10, 10, 10))


### PR DESCRIPTION
This PR adds the lesion-wise metrics (`lesion_ppv`, `lesion_sensitivity`, and `lesion_f1_score`) proposed in https://github.com/ivadomed/MetricsReloaded/pull/3 to our our [compute_metrics/compute_metrics_reloaded.py](https://github.com/ivadomed/utilities/blob/083054b18288ca5cac190442ae92fb3a282f72b8/compute_metrics/compute_metrics_reloaded.py) script.

To test the branch, please follow our installation instructions [here](https://github.com/ivadomed/utilities/blob/main/quick_start_guides/MetricsReloaded_quick_start_guide.md) and then you can run our [compute_metrics/compute_metrics_reloaded.py](https://github.com/ivadomed/utilities/blob/083054b18288ca5cac190442ae92fb3a282f72b8/compute_metrics/compute_metrics_reloaded.py) script on your images, for example:

```console
python compute_metrics_reloaded.py
-reference sub-001_T2w_gt.nii.gz 
-prediction sub-001_T2w_prediction.nii.gz 
-metrics lesion_ppv lesion_sensitivity lesion_f1_score
```

Please also review unit tests in [tests/test_compute_metrics_reloaded.py](https://github.com/ivadomed/utilities/blob/083054b18288ca5cac190442ae92fb3a282f72b8/tests/test_compute_metrics_reloaded.py) for different scenarios ([empty gt and non-empty pred](https://github.com/ivadomed/utilities/blob/083054b18288ca5cac190442ae92fb3a282f72b8/tests/test_compute_metrics_reloaded.py#L76-L91), [non-empty gt and non-empty pred with partial overlap](https://github.com/ivadomed/utilities/blob/083054b18288ca5cac190442ae92fb3a282f72b8/tests/test_compute_metrics_reloaded.py#L130-L145), etc.).

Tagging @naga-karthik, @plbenveniste, and @Nilser3, who work with lesions and thus this PR is super relevant to them.

Resolves: https://github.com/ivadomed/utilities/issues/49